### PR TITLE
SAS-159 alert if can't create a user

### DIFF
--- a/src/components/LogIn/LogIn.js
+++ b/src/components/LogIn/LogIn.js
@@ -36,22 +36,23 @@ export default function LogIn() {
 
   const loginHandler = async (e) => {
     e.preventDefault();
-    setUserName(username);
-
     const url = "http://localhost:8000/users";
-
     //build de url with the params
     const params = "?username=" + username;
     const urlFinal = url + params;
 
-    axios
+    await axios
       .post(urlFinal)
       .then((response) => {
         console.log("Solicitud POST exitosa", response.data);
         setUserId(response.data.id);
+        setUserName(username);
       })
       .catch((error) => {
         console.error("Error en la solicitud POST", error);
+        if (error.response.status === 500) {
+          alert(error.response.data.detail);
+        }
       });
   };
 


### PR DESCRIPTION
Avisar a través de una alerta de que no se pudo crear un usuario. Ejemplo si ya existía un usuario con ese nombre, informar por pantalla.
Además si ocurre un error, no avanzar a la vista del home, sino dejar al usuario ingresar el nombre de nuevo.