### PR TITLE
Sas 326 - restrict cards that are not playable

### DIFF
--- a/src/components/GameComps/GameButtons.js
+++ b/src/components/GameComps/GameButtons.js
@@ -5,6 +5,7 @@ import Button from "@mui/material/Button";
 import ListItem from "@mui/material/ListItem";
 import { useWebSocket } from "../../contexts/WebsocketContext";
 import { UserContext } from "../../contexts/UserContext";
+import { isCardPlaylable } from "../../utils/CardHandler";
 
 const Buttons = ({
   current_player,
@@ -33,10 +34,22 @@ const Buttons = ({
     turnPhase === "Exchange" || turnPhase === "Exchange_defense";
   const exchangeEnabledDefense =
     target_player === userid && !isDefended && exchangeEnabled && clickedCard;
-
+  if (clickedCard) {
+    console.log(
+      "isCardPlaylable",
+      isCardPlaylable(clickedCard.idtype, false, "", false, false, false)
+    );
+  }
   const playEnabled =
-    (isTurn && isCardClicked && !exchangeEnabled) ||
-    (isCardTarget && isCardClicked && isTurn && !exchangeEnabled) ||
+    (isTurn &&
+      isCardClicked &&
+      !exchangeEnabled &&
+      isCardPlaylable(clickedCard.idtype, false, "", false, false, false)) ||
+    (isCardTarget &&
+      isCardClicked &&
+      isTurn &&
+      !exchangeEnabled &&
+      isCardPlaylable(clickedCard.idtype, false, "", false, false, false)) ||
     (isDefended && target_player === userid);
 
   const playEnabledDisc =

--- a/src/components/GameComps/Hand.js
+++ b/src/components/GameComps/Hand.js
@@ -11,6 +11,8 @@ const Hand = ({
   target_player,
   isSomeoneBeingDefended,
   role,
+  isPlayPhase,
+  cardTargetRole,
 }) => {
   const { clickedCard, onCardClicked, userid, isExchangePhase } =
     useContext(UserContext);
@@ -19,6 +21,7 @@ const Hand = ({
   const isDefensePhase = isSomeoneBeingDefended && isDefended;
   let canExchangeInfected = false; // si el rol es infectado, tiene q tener al menos de cartas de Infected
   let infectedCards = 0;
+  console.log("isPlayPhase", isPlayPhase);
 
   const baseCardStyle = {
     width: "10%",
@@ -40,14 +43,14 @@ const Hand = ({
   };
 
   const onClickedCard = ({ id, idtype, isDefenseCard }) => {
-    console.log("isExchangePhase: ", isExchangePhase);
     if (
       !isCardPlaylable(
         idtype,
         isExchangePhase,
         role,
         isDefensePhase,
-        canExchangeInfected
+        canExchangeInfected,
+        isPlayPhase
       )
     ) {
       onCardClicked(null);
@@ -80,7 +83,13 @@ const Hand = ({
           );
           if (role === "Infected") {
             if (idtype === 2) infectedCards++;
-            if (infectedCards >= 2) canExchangeInfected = true;
+            if (infectedCards >= 2) {
+              if (cardTargetRole === "The Thing" && isDefended) {
+                canExchangeInfected = true;
+              } else if (!isDefended) {
+                canExchangeInfected = true;
+              }
+            }
           }
           return (
             <Box
@@ -93,7 +102,8 @@ const Hand = ({
                     isExchangePhase,
                     role,
                     isDefensePhase,
-                    canExchangeInfected
+                    canExchangeInfected,
+                    isPlayPhase
                   ) &&
                   (isSomeoneBeingDefended
                     ? isDefended && isDefenseCard
@@ -109,7 +119,8 @@ const Hand = ({
                       isExchangePhase,
                       role,
                       isDefensePhase,
-                      canExchangeInfected
+                      canExchangeInfected,
+                      isPlayPhase
                     )
                       ? {}
                       : isSomeoneBeingDefended

--- a/src/components/GameTable/GameTable.js
+++ b/src/components/GameTable/GameTable.js
@@ -15,6 +15,7 @@ const GameTable = ({
   turnDefense,
   isSomeoneBeingDefended,
   turnPhase,
+  the_thing_id,
 }) => {
   const { gameId } = useParams();
   const {
@@ -165,6 +166,16 @@ const GameTable = ({
         CardHasTarget(clickedCard.idtype) === CntTarget.ALL
       ) {
         return () => handlePlayCard(id);
+      }
+    } else if (
+      turnPhase === "Exchange" &&
+      currentTurn === userid &&
+      the_thing_id !== userid &&
+      clickedCard &&
+      clickedCard.idtype === 2
+    ) {
+      if (id === the_thing_id) {
+        return () => handleExchange(id);
       }
     } else if (
       turnPhase === "Exchange" &&

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -12,6 +12,7 @@ export const UserProvider = ({ children }) => {
   const [playedCard, setPlayedCard] = useState(null);
   const [targetsEnable, setTargetsEnable] = useState(null);
   const [targetId, setTargetId] = useState(null);
+  const [isExchangePhase, setIsExchangePhase] = useState(false);
 
   const onCardClicked = useCallback(
     (card) => {
@@ -50,6 +51,8 @@ export const UserProvider = ({ children }) => {
         setPlayedCard,
         targetId,
         setTargetId,
+        isExchangePhase,
+        setIsExchangePhase,
       }}
     >
       {children}

--- a/src/utils/CardHandler.js
+++ b/src/utils/CardHandler.js
@@ -166,3 +166,52 @@ export function CardHasTarget(id) {
   // console.log("la id es", id);
   return cardTargets[id];
 }
+
+export function isCardPlaylable(
+  idtype,
+  isExchangePhase,
+  role,
+  isDefensePhase,
+  canExchangeInfected
+) {
+  let isPlaylable = false;
+  const cardAssets = {
+    1: false,
+    2:
+      isExchangePhase &&
+      (role === "The Thing" || (role === "Infected" && canExchangeInfected)),
+    3: true,
+    4: true,
+    5: true,
+    6: true,
+    7: true,
+    8: true,
+    9: true,
+    10: true,
+    11: true,
+    12: true,
+    13: isDefensePhase || isExchangePhase,
+    14: isDefensePhase || isExchangePhase,
+    15: isDefensePhase || isExchangePhase,
+    16: isDefensePhase || isExchangePhase,
+    17: isDefensePhase || isExchangePhase,
+    18: true,
+    19: true,
+    20: true,
+    21: true,
+    22: true,
+    23: true,
+    24: true,
+    25: true,
+    26: true,
+    27: true,
+    28: true,
+    29: true,
+    30: true,
+    31: true,
+  };
+
+  isPlaylable = cardAssets[idtype];
+
+  return isPlaylable;
+}

--- a/src/utils/CardHandler.js
+++ b/src/utils/CardHandler.js
@@ -124,11 +124,12 @@ export const CntTarget = Object.freeze({
   NONE: 0,
   ADJACENT: 1,
   ALL: 2,
+  THE_THING: 3,
 });
 
 const cardTargets = {
   1: CntTarget.NONE,
-  2: CntTarget.NONE,
+  2: CntTarget.THE_THING,
   3: CntTarget.ADJACENT,
   4: CntTarget.ADJACENT,
   5: CntTarget.ADJACENT, // hacha: a vos mismo o adjacente
@@ -172,14 +173,17 @@ export function isCardPlaylable(
   isExchangePhase,
   role,
   isDefensePhase,
-  canExchangeInfected
+  canExchangeInfected,
+  isPlayPhase
 ) {
   let isPlaylable = false;
   const cardAssets = {
     1: false,
     2:
-      isExchangePhase &&
-      (role === "The Thing" || (role === "Infected" && canExchangeInfected)),
+      (isExchangePhase &&
+        (role === "The Thing" ||
+          (role === "Infected" && canExchangeInfected))) ||
+      isPlayPhase,
     3: true,
     4: true,
     5: true,
@@ -190,11 +194,11 @@ export function isCardPlaylable(
     10: true,
     11: true,
     12: true,
-    13: isDefensePhase || isExchangePhase,
-    14: isDefensePhase || isExchangePhase,
-    15: isDefensePhase || isExchangePhase,
-    16: isDefensePhase || isExchangePhase,
-    17: isDefensePhase || isExchangePhase,
+    13: isDefensePhase || isExchangePhase || isPlayPhase,
+    14: isDefensePhase || isExchangePhase || isPlayPhase,
+    15: isDefensePhase || isExchangePhase || isPlayPhase,
+    16: isDefensePhase || isExchangePhase || isPlayPhase,
+    17: isDefensePhase || isExchangePhase || isPlayPhase,
     18: true,
     19: true,
     20: true,

--- a/src/views/Game/Game.js
+++ b/src/views/Game/Game.js
@@ -19,8 +19,14 @@ import { ActionLog } from "../../components/ActionLog/ActionLog";
 
 const Game = () => {
   const { gameId } = useParams();
-  const { userid, playedCard, setPlayedCard, targetId, setClickedCard } =
-    useContext(UserContext);
+  const {
+    userid,
+    playedCard,
+    setPlayedCard,
+    targetId,
+    setClickedCard,
+    setIsExchangePhase,
+  } = useContext(UserContext);
 
   //game data
   const [finished, setFinished] = useState(false);
@@ -120,6 +126,11 @@ const Game = () => {
       setTurnPhase(json.game.turn_phase);
       setTurnOrder(json.game.turn_order);
       setIsLoading(false);
+      if (json.game.turn_phase === "Exchange") {
+        setIsExchangePhase(true);
+        console.log("es fase de intercambio");
+      }
+
       if (json.game.status === "Finished") {
         setFinished(true);
         setWinner(json.game.winners);
@@ -192,6 +203,7 @@ const Game = () => {
       setDefendedBy([]);
       setLastChosenCard(null);
       setExchangeRequester(null);
+      setIsExchangePhase(false);
     } else if (json.type === "show_card") {
       const targetArray = json.target;
 
@@ -423,6 +435,7 @@ const Game = () => {
                     defense={defended_by}
                     target_player={card_target}
                     isSomeoneBeingDefended={isSomeoneBeingDefended}
+                    role={players.find((player) => player.id === userid).role}
                   />
                 </Grid>
                 <Box

--- a/src/views/Game/Game.js
+++ b/src/views/Game/Game.js
@@ -48,6 +48,7 @@ const Game = () => {
   const [carsToShow, setCarsToShow] = useState([]);
   const [player_name, setPlayerName] = useState(null);
   const [winner, setWinner] = useState(null);
+  const [isPlayPhase, setIsPlayPhase] = useState(false);
 
   const { websocket } = useWebSocket();
   const [isLoading, setIsLoading] = useState(true);
@@ -129,6 +130,8 @@ const Game = () => {
       if (json.game.turn_phase === "Exchange") {
         setIsExchangePhase(true);
         console.log("es fase de intercambio");
+      } else {
+        setIsPlayPhase(true);
       }
 
       if (json.game.status === "Finished") {
@@ -153,6 +156,7 @@ const Game = () => {
       setTurnPhase(json.turn_phase);
     } else if (json.type === "try_defense") {
       setLastPlayedCard(json.played_card);
+      setIsPlayPhase(false);
       if (json.target_player === 0 && last_played_card !== null) {
         if (last_played_card === null) {
           const messageData = JSON.stringify({
@@ -180,6 +184,7 @@ const Game = () => {
       setIsSomeoneBeingDefended(false);
       setCardTarget(null);
       setDefendedBy([]);
+      setIsPlayPhase(false);
       if (json.target_player === 0 || json.played_defense === 0) {
         setShowPlayedCard(json.last_played_card.idtype);
       } else {
@@ -353,6 +358,9 @@ const Game = () => {
               isSomeoneBeingDefended={isSomeoneBeingDefended}
               turnExchange={card_target}
               turnPhase={turn_phase}
+              the_thing_id={
+                players.find((player) => player.role === "The Thing").id
+              }
             />
             <Box>
               <Grid
@@ -436,6 +444,17 @@ const Game = () => {
                     target_player={card_target}
                     isSomeoneBeingDefended={isSomeoneBeingDefended}
                     role={players.find((player) => player.id === userid).role}
+                    isPlayPhase={isPlayPhase}
+                    cardTargetRole={
+                      card_target !== null && exchange_requester !== null
+                        ? card_target !== userid
+                          ? players.find((player) => player.id === card_target)
+                              .role
+                          : players.find(
+                              (player) => player.id === exchange_requester
+                            ).role
+                        : null
+                    }
                   />
                 </Grid>
                 <Box


### PR DESCRIPTION
No te deberá dejar seleccionar ciertas cartas si las reglas del juego no lo permiten.

Casos:
- La carta la cosa, infectado, etc no son jugables/defendibles en ningún momento
- Cartas infectado solo habilitadas en fase de intercambio, se las podes intercambiar solo a la cosa.
- Cartas de defensa no habilitadas para jugar

Aclaración: ver bien los [criterios de aceptación](https://ingsoft-grupito.atlassian.net/browse/SAS-326), que funcione en todos los casos.