### PR TITLE
SAS-329

### DIFF
--- a/src/components/GameComps/GameButtons.js
+++ b/src/components/GameComps/GameButtons.js
@@ -30,6 +30,7 @@ const Buttons = ({
   const isCardTarget = target_player === targetId;
   const isTurn = current_player === userid && !isDefended;
   const isCardClicked = clickedCard !== null && !targetsEnable;
+  const isCardWithTargetClicked = clickedCard !== null && targetsEnable;
   const exchangeEnabled =
     turnPhase === "Exchange" || turnPhase === "Exchange_defense";
   const exchangeEnabledDefense =
@@ -52,8 +53,15 @@ const Buttons = ({
       isCardPlaylable(clickedCard.idtype, false, "", false, false, false)) ||
     (isDefended && target_player === userid);
 
-  const playEnabledDisc =
-    isTurn && isCardClicked && !isDefended && !exchangeEnabled;
+    const playEnabledDisc =
+    (isTurn &&
+      isCardClicked &&
+      !isDefended &&
+      !exchangeEnabled) ||
+    (isTurn &&
+      isCardWithTargetClicked &&
+      !isDefended &&
+      !exchangeEnabled);
 
   const handlePlayCard = () => {
     if (websocket) {

--- a/src/components/GameComps/Hand.js
+++ b/src/components/GameComps/Hand.js
@@ -35,10 +35,6 @@ const Hand = ({
     transform: "scale(1.1)",
   };
 
-  const auraStyle = {
-    boxShadow: "2px 2px 4px #FFFFF",
-  };
-
   const onClickedCard = ({ id, idtype, isDefenseCard }) => {
     if (
       !isCardPlaylable(
@@ -65,7 +61,9 @@ const Hand = ({
   };
 
   const isCardPlayableOnHover = ({ id, idtype, isDefenseCard }) => {
-    return (
+    return ((
+      !isDefended &&
+      !isDefenseCard &&
       isCardPlaylable(
         idtype,
         isExchangePhase,
@@ -73,7 +71,7 @@ const Hand = ({
         isDefensePhase,
         canExchangeInfected,
         isPlayPhase
-      ) ||
+      )) ||
       (isSomeoneBeingDefended &&
         isDefended &&
         isDefenseCard &&
@@ -124,10 +122,8 @@ const Hand = ({
                 right: `${10 + index * 30}px`,
                 "&:hover": {
                   ...(isCardPlayableOnHover({ id, idtype, isDefenseCard }) && highlightedCardStyle),
-                  ...(isSomeoneBeingDefended && isDefended && isDefenseCard && auraStyle),
                 },
                 ...(isClicked && highlightedCardStyle),
-                ...(isDefenseCard && auraStyle),
               }}
               onClick={() => onClickedCard({ id, idtype, isDefenseCard })}
             >

--- a/src/components/GameComps/Hand.js
+++ b/src/components/GameComps/Hand.js
@@ -1,7 +1,5 @@
 import { useContext } from "react";
-
 import { Box } from "@mui/material";
-
 import { UserContext } from "../../contexts/UserContext";
 import { IdToAsset, isCardPlaylable } from "../../utils/CardHandler";
 
@@ -19,9 +17,8 @@ const Hand = ({
 
   const isDefended = target_player === userid;
   const isDefensePhase = isSomeoneBeingDefended && isDefended;
-  let canExchangeInfected = false; // si el rol es infectado, tiene q tener al menos de cartas de Infected
+  let canExchangeInfected = false;
   let infectedCards = 0;
-  console.log("isPlayPhase", isPlayPhase);
 
   const baseCardStyle = {
     width: "10%",
@@ -67,6 +64,30 @@ const Hand = ({
     }
   };
 
+  const isCardPlayableOnHover = ({ id, idtype, isDefenseCard }) => {
+    return (
+      isCardPlaylable(
+        idtype,
+        isExchangePhase,
+        role,
+        isDefensePhase,
+        canExchangeInfected,
+        isPlayPhase
+      ) ||
+      (isSomeoneBeingDefended &&
+        isDefended &&
+        isDefenseCard &&
+        isCardPlaylable(
+          idtype,
+          isExchangePhase,
+          role,
+          isDefensePhase,
+          canExchangeInfected,
+          isPlayPhase
+        ))
+    );
+  };
+
   return (
     <div>
       <div
@@ -78,9 +99,11 @@ const Hand = ({
         id="hand"
       >
         {cardList?.map(({ id, idtype }, index) => {
+          const isClicked = clickedCard?.id === id;
           const isDefenseCard = defense.some(
             (elem) => isDefended && elem === idtype
           );
+
           if (role === "Infected") {
             if (idtype === 2) infectedCards++;
             if (infectedCards >= 2) {
@@ -91,48 +114,21 @@ const Hand = ({
               }
             }
           }
+
           return (
             <Box
               key={`card-hand-${id}`}
               id={`card-hand-${index}`}
-              sx={[
-                clickedCard?.id === id &&
-                  !isCardPlaylable(
-                    idtype,
-                    isExchangePhase,
-                    role,
-                    isDefensePhase,
-                    canExchangeInfected,
-                    isPlayPhase
-                  ) &&
-                  (isSomeoneBeingDefended
-                    ? isDefended && isDefenseCard
-                      ? highlightedCardStyle
-                      : false
-                    : highlightedCardStyle),
-                {
-                  ...baseCardStyle,
-                  right: `${10 + index * 30}px`,
-                  "&:hover": {
-                    ...(!isCardPlaylable(
-                      idtype,
-                      isExchangePhase,
-                      role,
-                      isDefensePhase,
-                      canExchangeInfected,
-                      isPlayPhase
-                    )
-                      ? {}
-                      : isSomeoneBeingDefended
-                      ? isDefended && isDefenseCard
-                        ? highlightedCardStyle
-                        : {}
-                      : highlightedCardStyle),
-                    ...(isDefenseCard && auraStyle),
-                  },
-                  ...(isDefenseCard && auraStyle),
+              sx={{
+                ...baseCardStyle,
+                right: `${10 + index * 30}px`,
+                "&:hover": {
+                  ...(isCardPlayableOnHover({ id, idtype, isDefenseCard }) && highlightedCardStyle),
+                  ...(isSomeoneBeingDefended && isDefended && isDefenseCard && auraStyle),
                 },
-              ]}
+                ...(isClicked && highlightedCardStyle),
+                ...(isDefenseCard && auraStyle),
+              }}
               onClick={() => onClickedCard({ id, idtype, isDefenseCard })}
             >
               <img


### PR DESCRIPTION
Se corrigieron los bugs de el hover a la carta seleccionada y el boton de descarte para cartas con target.
Para probarlo:

- Iniciar partida con al menos 4 jugadores
- Ir a la pestaña que contiene el jugador de turno y probar que al pasar el mouse por encima de las cartas, se hace el efecto hover sobre todas menos sobre la carta la cosa.
- Clickear una carta cualquiera (que no sea la cosa) y esta deberia mantenerse con el efecto hover
- Clicker una carta con target y apretar el boton de descarte